### PR TITLE
Skip Require on CircleCI for `rspec` / `rubocop`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,6 @@ workflows:
       - rspec
       - rubocop
       - release:
-          requires:
-            - rspec
-            - rubocop
           filters:
             branches:
               ignore: /.*/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-mistral (1.0.3)
+    omniai-mistral (1.0.4)
       event_stream_parser
       omniai
       zeitwerk

--- a/lib/omniai/mistral/version.rb
+++ b/lib/omniai/mistral/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Mistral
-    VERSION = '1.0.3'
+    VERSION = '1.0.4'
   end
 end


### PR DESCRIPTION
Skipping since release command is not running on CircleCI.