### PR TITLE
Support the Prompt Builder

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-mistral (1.5.0)
+    omniai-mistral (1.6.0)
       event_stream_parser
       omniai
       zeitwerk
@@ -50,7 +50,7 @@ GEM
     llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
-    omniai (1.5.0)
+    omniai (1.6.0)
       event_stream_parser
       http
       zeitwerk
@@ -63,7 +63,7 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.9.2)
-    rexml (3.3.1)
+    rexml (3.3.2)
       strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -95,7 +95,7 @@ GEM
       parser (>= 3.3.1.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
-    rubocop-rspec (3.0.2)
+    rubocop-rspec (3.0.3)
       rubocop (~> 1.61)
     ruby-progressbar (1.13.0)
     simplecov (0.22.0)

--- a/README.md
+++ b/README.md
@@ -46,21 +46,10 @@ completion.choice.message.content # 'Why did the chicken cross the road? To get 
 ```
 
 ```ruby
-completion = client.chat({
-  role: OmniAI::Chat::Role::USER,
-  content: 'Is it wise to jump off a bridge?'
-})
-completion.choice.message.content # 'No.'
-```
-
-```ruby
-completion = client.chat([
-  {
-    role: OmniAI::Chat::Role::SYSTEM,
-    content: 'You are a helpful assistant.'
-  },
-  'What is the capital of Canada?',
-])
+completion = client.chat do |prompt|
+  prompt.system('You are a helpful assistant.')
+  prompt.user('What is the capital of Canada?')
+end
 completion.choice.message.content # 'The capital of Canada is Ottawa.'
 ```
 
@@ -104,10 +93,10 @@ client.chat('Be poetic.', stream:)
 `format` takes an optional symbol (`:json`) and that sets the `response_format` to `json_object`:
 
 ```ruby
-completion = client.chat([
-  { role: OmniAI::Chat::Role::SYSTEM, content: OmniAI::Chat::JSON_PROMPT },
-  { role: OmniAI::Chat::Role::USER, content: 'What is the name of the drummer for the Beatles?' }
-], format: :json)
+completion = client.chat(format: :json) do |prompt|
+  prompt.system(OmniAI::Chat::JSON_PROMPT)
+  prompt.user('What is the name of the drummer for the Beatles?')
+end
 JSON.parse(completion.choice.message.content) # { "name": "Ringo" }
 ```
 

--- a/lib/omniai/mistral/chat.rb
+++ b/lib/omniai/mistral/chat.rb
@@ -32,7 +32,7 @@ module OmniAI
       # @return [Hash]
       def payload
         OmniAI::Mistral.config.chat_options.merge({
-          messages:,
+          messages: @prompt.serialize,
           model: @model,
           stream: @stream.nil? ? nil : !@stream.nil?,
           temperature: @temperature,

--- a/lib/omniai/mistral/version.rb
+++ b/lib/omniai/mistral/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Mistral
-    VERSION = '1.5.0'
+    VERSION = '1.6.0'
   end
 end

--- a/spec/omniai/mistral/chat_spec.rb
+++ b/spec/omniai/mistral/chat_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe OmniAI::Mistral::Chat do
 
     context 'with an array prompt' do
       let(:prompt) do
-        [
-          { role: OmniAI::Chat::Role::SYSTEM, content: 'You are a helpful assistant.' },
-          { role: OmniAI::Chat::Role::USER, content: 'What is the capital of Canada?' },
-        ]
+        OmniAI::Chat::Prompt.build do |prompt|
+          prompt.system('You are a helpful assistant.')
+          prompt.user('What is the capital of Canada?')
+        end
       end
 
       before do
@@ -96,10 +96,10 @@ RSpec.describe OmniAI::Mistral::Chat do
       subject(:completion) { described_class.process!(prompt, client:, model:, format: :json) }
 
       let(:prompt) do
-        [
-          { role: OmniAI::Chat::Role::SYSTEM, content: OmniAI::Chat::JSON_PROMPT },
-          { role: OmniAI::Chat::Role::USER, content: 'What is the name of the dummer for the Beatles?' },
-        ]
+        OmniAI::Chat::Prompt.build do |prompt|
+          prompt.system(OmniAI::Chat::JSON_PROMPT)
+          prompt.user('What is the name of the dummer for the Beatles?')
+        end
       end
 
       before do


### PR DESCRIPTION
Compatibility with features like tools and files / URLs introduces a number of complexities when not using a standardized API for prompts. This swaps to use a better API when building prompts

## Usage

**w/ a basic prompt**

```ruby
completion = client.chat('What is the capital of Japan?')
```

**w/ a complex prompt**

```ruby
completion = client.chat do |prompt|
  prompt.system 'You are a helpful assistant with an expertise in animals.'
  prompt.user do |message|
    message.text 'What animals are in the attached photos?'
    message.url('https://.../cat.jpeg', "image/jpeg")
    message.url('https://.../dog.jpeg', "image/jpeg")
    message.file('./hamster.jpeg', "image/jpeg")
  end
end
```