### PR TITLE
Handle Blank Tools

### DIFF
--- a/lib/omniai/mistral/chat.rb
+++ b/lib/omniai/mistral/chat.rb
@@ -39,7 +39,7 @@ module OmniAI
           stream: @stream.nil? ? nil : !@stream.nil?,
           temperature: @temperature,
           response_format: (JSON_RESPONSE_FORMAT if @format.eql?(:json)),
-          tools: @tools&.map(&:serialize),
+          tools: (@tools.map(&:serialize) if @tools&.any?),
         }).compact
       end
 


### PR DESCRIPTION
Handle the case where blank tools (e.g. an empty array) is supplied for tools.