### PR TITLE
Properly Lock Version of the Parent Library

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    omniai-mistral (1.9.5)
+    omniai-mistral (1.9.6)
       event_stream_parser
-      omniai
+      omniai (~> 1.9)
       zeitwerk
 
 GEM

--- a/lib/omniai/mistral/version.rb
+++ b/lib/omniai/mistral/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Mistral
-    VERSION = "1.9.5"
+    VERSION = "1.9.6"
   end
 end

--- a/omniai-mistral.gemspec
+++ b/omniai-mistral.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "event_stream_parser"
-  spec.add_dependency "omniai"
+  spec.add_dependency "omniai", "~> 1.9"
   spec.add_dependency "zeitwerk"
 end


### PR DESCRIPTION
This ensures the v2.0 release of OmniAI does not break everything.