### PR TITLE
Support OCR API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-mistral (2.0.0)
+    omniai-mistral (2.0.1)
       event_stream_parser
       omniai (~> 2.0)
       zeitwerk

--- a/examples/ocr
+++ b/examples/ocr
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "omniai/mistral"
+
+CLIENT = OmniAI::Mistral::Client.new
+
+URL = "https://vancouver.ca/files/cov/other-sectors-tourism.PDF"
+
+response = CLIENT.ocr(URL)
+
+response.pages.each do |page|
+  puts "INDEX=#{page.index}"
+  puts page.markdown
+end

--- a/lib/omniai/mistral.rb
+++ b/lib/omniai/mistral.rb
@@ -6,6 +6,7 @@ require "zeitwerk"
 
 loader = Zeitwerk::Loader.for_gem
 loader.push_dir(__dir__, namespace: OmniAI)
+loader.inflector.inflect "ocr" => "OCR"
 loader.setup
 
 module OmniAI

--- a/lib/omniai/mistral/client.rb
+++ b/lib/omniai/mistral/client.rb
@@ -54,7 +54,7 @@ module OmniAI
       # @yield [prompt] optional
       # @yieldparam prompt [OmniAI::Chat::Prompt]
       #
-      # @return [OmniAI::Chat::Completion]
+      # @return [OmniAI::Chat::Response]
       def chat(messages = nil, model: Chat::DEFAULT_MODEL, temperature: nil, format: nil, stream: nil, tools: nil, &)
         Chat.process!(messages, model:, temperature:, format:, stream:, tools:, client: self, &)
       end
@@ -63,8 +63,24 @@ module OmniAI
       #
       # @param input [String, Array<String>, Array<Integer>] required
       # @param model [String] optional
+      #
+      # @return [OmniAI::Embed::Response]
       def embed(input, model: Embed::DEFAULT_MODEL)
         Embed.process!(input, model:, client: self)
+      end
+
+      # @raise [OmniAI::Error]
+      #
+      # @param document [String] e.g. "https://vancouver.ca/files/cov/other-sectors-tourism.PDF"
+      # @param kind [Symbol] optional - `:document` or `:image` - default = `:document``
+      # @param model [String] optional - default = "mistral-ocr-latest"
+      # @param options [Hash] optional - e.g. `{ image_limit: 4 }`
+      #
+      # @raise [OmniAI::Error]
+      #
+      # @return [OmniAI::Mistral::OCR::Response]
+      def ocr(document, kind: OCR::DEFAULT_KIND, model: OCR::DEFAULT_MODEL, options: {})
+        OCR.process!(document, kind:, model:, options:, client: self)
       end
     end
   end

--- a/lib/omniai/mistral/ocr.rb
+++ b/lib/omniai/mistral/ocr.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module OmniAI
+  module Mistral
+    # An implementation of the OCR API.
+    class OCR
+      VERSION = "v1"
+
+      module Kind
+        DOCUMENT = :document
+        IMAGE = :image
+      end
+
+      module Model
+        OCR_LATEST = "mistral-ocr-latest"
+      end
+
+      DEFAULT_KIND = Kind::DOCUMENT
+      DEFAULT_MODEL = Model::OCR_LATEST
+
+      # @raise [Error]
+      #
+      # @param client [OmniAI::Mistral::Client]
+      # @param document [String] a URL
+      # @param kind [Symbol] optional
+      # @param model [String] optional
+      # @param options [Hash] optional (e.g. `{ image_limit: 4 }`)
+      #
+      # @return [Response]
+      def self.process!(document, client:, kind: DEFAULT_KIND, model: DEFAULT_MODEL, options: {})
+        new(document, client:, kind:, model:, options:).process!
+      end
+
+      # @param client [OmniAI::Mistral::Client]
+      # @param document [String] a URL
+      # @param kind [Symbol] optional
+      # @param model [String] optional
+      # @param options [Hash] optional (e.g. `{ image_limit: 4 }`)
+      def initialize(document, client:, kind: DEFAULT_KIND, model: DEFAULT_MODEL, options: {})
+        @document = document
+        @client = client
+        @options = options
+        @kind = kind
+        @model = model
+      end
+
+      # @raise [Error]
+      #
+      # @return [Response]
+      def process!
+        response = @client.connection.accept(:json).post("/#{VERSION}/ocr", json: @options.merge({
+          model: @model,
+          document: document!,
+        }).compact)
+
+        raise HTTPError, response.flush unless response.status.ok?
+
+        Response.parse(data: response.parse)
+      end
+
+      # @return [Hash]
+      def document!
+        case @kind
+        when Kind::DOCUMENT then { document_url: @document, type: "document_url" }
+        when Kind::IMAGE then { image_url: @document, type: "image_url" }
+        end
+      end
+    end
+  end
+end

--- a/lib/omniai/mistral/ocr/dimensions.rb
+++ b/lib/omniai/mistral/ocr/dimensions.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module OmniAI
+  module Mistral
+    class OCR
+      # Dimensions returned by the OCR API.
+      class Dimensions
+        # !@attribute [rw] width
+        #   @return [Integer]
+        attr_accessor :width
+
+        # !@attribute [rw] height
+        #   @return [Integer]
+        attr_accessor :height
+
+        # !@attribute [rw] dpi
+        #   @return [Integer]
+        attr_accessor :dpi
+
+        # @param width [Integer]
+        # @param height [Integer]
+        # @param dpi [Integer]
+        def initialize(width:, height:, dpi:)
+          @width = width
+          @height = height
+          @dpi = dpi
+        end
+
+        # @param data [Hash]
+        #
+        # @return [Dimensions]
+        def self.parse(data:)
+          new(width: data["width"], height: data["height"], dpi: data["dpi"])
+        end
+      end
+    end
+  end
+end

--- a/lib/omniai/mistral/ocr/image.rb
+++ b/lib/omniai/mistral/ocr/image.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module OmniAI
+  module Mistral
+    class OCR
+      # An image returned by the OCR API.
+      class Image
+        # !@attribute [rw] id
+        #   @return [Integer]
+        attr_accessor :id
+
+        # !@attribute [rw] top_left_x
+        #   @return [Integer]
+        attr_accessor :top_left_x
+
+        # !@attribute [rw] top_left_y
+        #   @return [Integer]
+        attr_accessor :top_left_y
+
+        # !@attribute [rw] bottom_right_x
+        #   @return [Integer]
+        attr_accessor :bottom_right_x
+
+        # !@attribute [rw] bottom_right_y
+        #   @return [Integer]
+        attr_accessor :bottom_right_y
+
+        # !@attribute [rw] image_base64
+        #   @return [String]
+        attr_accessor :image_base64
+
+        # @param id [Integer]
+        # @param top_left_x [Integer]
+        # @param top_left_y [Integer]
+        # @param bottom_right_x [Integer]
+        # @param bottom_right_y [Integer]
+        # @param image_base64 [String]
+        def initialize(id:, top_left_x:, top_left_y:, bottom_right_x:, bottom_right_y:, image_base64:)
+          @id = id
+          @top_left_x = top_left_x
+          @top_left_y = top_left_y
+          @bottom_right_x = bottom_right_x
+          @bottom_right_y = bottom_right_y
+          @image_base64 = image_base64
+        end
+
+        # @param data [Hash]
+        #
+        # @return [Image]
+        def self.parse(data:)
+          new(
+            id: data["id"],
+            top_left_x: data["top_left_x"],
+            top_left_y: data["top_left_y"],
+            bottom_right_x: data["bottom_right_x"],
+            bottom_right_y: data["bottom_right_y"],
+            image_base64: data["image_base64"]
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/omniai/mistral/ocr/page.rb
+++ b/lib/omniai/mistral/ocr/page.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module OmniAI
+  module Mistral
+    class OCR
+      # A page returned by the OCR API.
+      class Page
+        # !@attribute [rw] index
+        #   @return [Integer]
+        attr_accessor :index
+
+        # !@attribute [rw] markdown
+        #   @return [String]
+        attr_accessor :markdown
+
+        # !@attribute [rw] images
+        #   @return [Array<Image>]
+        attr_accessor :images
+
+        # !@attribute [rw] dimensions
+        #   @return [Dimensions]
+        attr_accessor :dimensions
+
+        # @param index [Integer]
+        # @param markdown [String]
+        # @param images [Array<Image>]
+        # @param dimensions [Dimensions]
+        def initialize(index:, markdown:, images:, dimensions:)
+          @index = index
+          @markdown = markdown
+          @images = images
+          @dimensions = dimensions
+        end
+
+        # @param data [Hash]
+        #
+        # @return [Page]
+        def self.parse(data:)
+          new(
+            index: data["index"],
+            markdown: data["markdown"],
+            images: data["images"].map { |image_data| Image.parse(data: image_data) },
+            dimensions: Dimensions.parse(data: data["dimensions"])
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/omniai/mistral/ocr/response.rb
+++ b/lib/omniai/mistral/ocr/response.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module OmniAI
+  module Mistral
+    class OCR
+      # The response from the OCR API.
+      class Response
+        # !@attribute [rw] model
+        #   @return [Array<Model>]
+        attr_accessor :model
+
+        # !@attribute [rw] pages
+        #   @return [Array<Page>]
+        attr_accessor :pages
+
+        # @param model [String]
+        # @param pages [Array<Page>]
+        def initialize(model:, pages:)
+          @model = model
+          @pages = pages
+        end
+
+        # @param data [Hash]
+        #
+        # @return [Response]
+        def self.parse(data:)
+          new(model: data["model"], pages: data["pages"].map { |page| Page.parse(data: page) })
+        end
+      end
+    end
+  end
+end

--- a/lib/omniai/mistral/version.rb
+++ b/lib/omniai/mistral/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Mistral
-    VERSION = "2.0.0"
+    VERSION = "2.0.1"
   end
 end

--- a/spec/omniai/mistral/client_spec.rb
+++ b/spec/omniai/mistral/client_spec.rb
@@ -19,6 +19,14 @@ RSpec.describe OmniAI::Mistral::Client do
     end
   end
 
+  describe "#ocr" do
+    it "proxies" do
+      allow(OmniAI::Mistral::OCR).to receive(:process!)
+      client.ocr("http://localhost/sample")
+      expect(OmniAI::Mistral::OCR).to have_received(:process!)
+    end
+  end
+
   describe "#connection" do
     it { expect(client.connection).to be_a(HTTP::Client) }
   end

--- a/spec/omniai/mistral/ocr_spec.rb
+++ b/spec/omniai/mistral/ocr_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+RSpec.describe OmniAI::Mistral::OCR do
+  let(:client) { OmniAI::Mistral::Client.new }
+
+  describe ".process!" do
+    subject(:ocr) { described_class.process!(document, kind:, client:) }
+
+    let(:document) { "http://localhost/sample" }
+
+    context "when kind is document" do
+      let(:kind) { described_class::Kind::DOCUMENT }
+
+      before do
+        stub_request(:post, "https://api.mistral.ai/v1/ocr")
+          .with(body: {
+            model: "mistral-ocr-latest",
+            document: {
+              document_url: "http://localhost/sample",
+              type: "document_url",
+            },
+          })
+          .to_return_json(body: {
+            pages: [
+              {
+                index: 0,
+                markdown: "**Hello World**",
+                images: [
+                  { id: "image-1" },
+                  { id: "image-2" },
+                ],
+                dimensions: {
+                  dpi: 300,
+                  width: 2200,
+                  height: 1700,
+                },
+              },
+            ],
+            model: "mistral-ocr-latest",
+          })
+      end
+
+      it { expect(ocr).to be_a(described_class::Response) }
+      it { expect(ocr.pages[0]).to be_a(described_class::Page) }
+      it { expect(ocr.pages[0].markdown).to eq("**Hello World**") }
+      it { expect(ocr.pages[0].dimensions).to be_a(described_class::Dimensions) }
+      it { expect(ocr.pages[0].dimensions.dpi).to eq(300) }
+      it { expect(ocr.pages[0].dimensions.width).to eq(2200) }
+      it { expect(ocr.pages[0].dimensions.height).to eq(1700) }
+    end
+
+    context "when kind is image" do
+      let(:kind) { described_class::Kind::IMAGE }
+
+      before do
+        stub_request(:post, "https://api.mistral.ai/v1/ocr")
+          .with(body: {
+            model: "mistral-ocr-latest",
+            document: {
+              image_url: "http://localhost/sample",
+              type: "image_url",
+            },
+          })
+          .to_return_json(body: {
+            pages: [
+              {
+                index: 0,
+                markdown: "**Hello World**",
+                images: [
+                  { id: "image-1" },
+                  { id: "image-2" },
+                ],
+                dimensions: {
+                  dpi: 300,
+                  width: 2200,
+                  height: 1700,
+                },
+              },
+            ],
+            model: "mistral-ocr-latest",
+          })
+      end
+
+      it { expect(ocr).to be_a(described_class::Response) }
+      it { expect(ocr.pages[0]).to be_a(described_class::Page) }
+      it { expect(ocr.pages[0].markdown).to eq("**Hello World**") }
+      it { expect(ocr.pages[0].dimensions).to be_a(described_class::Dimensions) }
+      it { expect(ocr.pages[0].dimensions.dpi).to eq(300) }
+      it { expect(ocr.pages[0].dimensions.width).to eq(2200) }
+      it { expect(ocr.pages[0].dimensions.height).to eq(1700) }
+    end
+  end
+end


### PR DESCRIPTION
## Context

This is a client specific integration for OCR:

https://mistral.ai/news/mistral-ocr

This API is not global yet. TBD if other providers bring over support.

## Example

```ruby
require "omniai/mistral"

CLIENT = OmniAI::Mistral::Client.new

URL = "https://vancouver.ca/files/cov/other-sectors-tourism.PDF"

response = CLIENT.ocr(URL)

response.pages.each do |page|
  puts "INDEX=#{page.index}"
  puts page.markdown
end
```