### PR TITLE
Swap Rubocop Configuration from `require` to `plugins`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_gem:
   rubocop-basic: rubocop.yml
 
-require:
+plugins:
   - rubocop-rake
   - rubocop-rspec
 


### PR DESCRIPTION
This strictly fixes deprecation warnings w/ Rubocop.