### PR TITLE
Fix Yard Doc Issue with README.md

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,10 @@ jobs:
       - checkout
       - ruby/install-deps
       - run: bundle exec yard doc
+      - store_artifacts:
+          path: doc
+          destination: doc
+
   rspec:
     parameters:
       ruby-version:
@@ -43,12 +47,14 @@ jobs:
       - ruby/install-deps
       - ruby/rspec-test
       - codeclimate
+
   rubocop:
     executor: default
     steps:
       - checkout
       - ruby/install-deps
       - ruby/rubocop-check
+
   release:
     executor: default
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gemspec
 gem "irb"
 gem "logger"
 gem "rake"
+gem "redcarpet"
 gem "rspec"
 gem "rspec_junit_formatter"
 gem "rubocop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    omniai-mistral (2.2.0)
+    omniai-mistral (2.2.1)
       event_stream_parser
       omniai (~> 2.2)
       zeitwerk
@@ -80,6 +80,7 @@ GEM
     rake (13.2.1)
     rdoc (6.13.1)
       psych (>= 4.0.0)
+    redcarpet (3.6.1)
     regexp_parser (2.10.0)
     reline (0.6.0)
       io-console (~> 0.5)
@@ -156,6 +157,7 @@ DEPENDENCIES
   logger
   omniai-mistral!
   rake
+  redcarpet
   rspec
   rspec_junit_formatter
   rubocop

--- a/lib/omniai/mistral/version.rb
+++ b/lib/omniai/mistral/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Mistral
-    VERSION = "2.2.0"
+    VERSION = "2.2.1"
   end
 end


### PR DESCRIPTION
This fixes an issue with yard doc not properly parsing the README.md for links due to a missing redcarpet dependency.