### PR TITLE
Surface normalized finish_reason (via base) + adopt omniai 3.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    omniai-mistral (3.0.0)
+    omniai-mistral (3.1.0)
       event_stream_parser
-      omniai (~> 3.0)
+      omniai (~> 3.7)
       openssl
       zeitwerk
 
@@ -60,10 +60,10 @@ GEM
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     logger (1.7.0)
-    omniai (3.0.0)
+    omniai (3.7.0)
       base64
       event_stream_parser
-      http
+      http (~> 5)
       logger
       zeitwerk
     openssl (4.0.2)

--- a/lib/omniai/mistral/version.rb
+++ b/lib/omniai/mistral/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAI
   module Mistral
-    VERSION = "3.0.0"
+    VERSION = "3.1.0"
   end
 end

--- a/omniai-mistral.gemspec
+++ b/omniai-mistral.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "event_stream_parser"
-  spec.add_dependency "omniai", "~> 3.0"
+  spec.add_dependency "omniai", "~> 3.7"
   spec.add_dependency "openssl"
   spec.add_dependency "zeitwerk"
 end

--- a/spec/omniai/mistral/chat_spec.rb
+++ b/spec/omniai/mistral/chat_spec.rb
@@ -26,12 +26,16 @@ RSpec.describe OmniAI::Mistral::Chat do
                 role: "assistant",
                 content: "Two elephants fall off a cliff. Boom! Boom!",
               },
+              finish_reason: "stop",
             }],
           })
       end
 
-      it { expect(completion.choice.message.role).to eql("assistant") }
-      it { expect(completion.choice.message.content).to eql("Two elephants fall off a cliff. Boom! Boom!") }
+      it { expect(completion.choices.first.message.role).to eql("assistant") }
+      it { expect(completion.choices.first.message.content).to eql("Two elephants fall off a cliff. Boom! Boom!") }
+      it { expect(completion.choices.first.finish_reason.reason).to eq(:stop) }
+      it { expect(completion.finish_reason.reason).to eq(:stop) }
+      it { expect(completion.finish_reason.value).to eq("stop") }
     end
 
     context "with an array prompt" do
@@ -62,8 +66,8 @@ RSpec.describe OmniAI::Mistral::Chat do
           })
       end
 
-      it { expect(completion.choice.message.role).to eql("assistant") }
-      it { expect(completion.choice.message.content).to eql("The capital of Canada is Ottawa.") }
+      it { expect(completion.choices.first.message.role).to eql("assistant") }
+      it { expect(completion.choices.first.message.content).to eql("The capital of Canada is Ottawa.") }
     end
 
     context "with a temperature" do
@@ -92,8 +96,8 @@ RSpec.describe OmniAI::Mistral::Chat do
           })
       end
 
-      it { expect(completion.choice.message.role).to eql("assistant") }
-      it { expect(completion.choice.message.content).to eql("3") }
+      it { expect(completion.choices.first.message.role).to eql("assistant") }
+      it { expect(completion.choices.first.message.content).to eql("3") }
     end
 
     context "when formatting as JSON" do
@@ -127,8 +131,8 @@ RSpec.describe OmniAI::Mistral::Chat do
           })
       end
 
-      it { expect(completion.choice.message.role).to eql("assistant") }
-      it { expect(completion.choice.message.content).to eql('{ "name": "Ringo" }') }
+      it { expect(completion.choices.first.message.role).to eql("assistant") }
+      it { expect(completion.choices.first.message.content).to eql('{ "name": "Ringo" }') }
     end
 
     context "when streaming" do


### PR DESCRIPTION
## Summary

Surfaces `OmniAI::Chat::Response#finish_reason` (a normalized `FinishReason` value object) for Mistral. Mistral uses the base deserialize path (`choices[].finish_reason`), so the base gem's `CHAT_COMPLETIONS` normalization maps it for free — `stop` → `:stop`, `length` → `:length`, `tool_calls` → `:tool_call`, `content_filter` → `:filter`, unrecognized → `:other`, with the verbatim token preserved as `finish_reason.value`. **No Mistral-side extraction code is needed.**

## What changed

- Adds a spec asserting `response.finish_reason` / `choices.first.finish_reason` (`.reason` + verbatim `.value`) for a Mistral completion.
- Bumps the `omniai` floor to `~> 3.7`, where the `FinishReason` contract lives.
- Adopting omniai 3.7 surfaced a stale-spec fix: the spec used `completion.choice`, the singular `Response#choice(index:)` helper that shipped in omniai **3.0.0** (Mistral's previously-pinned version — verified in the `v3.0.0` tag and the installed 3.0.0 gem) and was dropped from the base in a later release. The modern base exposes only `choices`, so those references are updated to `completion.choices.first...`. Mistral's production code never used `.choice`; this is spec-only.

## Tests

`35 examples, 0 failures`; rubocop clean.

## Dependency / release ordering

Releases as **omniai-mistral 3.1.0**.

⚠️ **Depends on omniai 3.7.0** (ksylvest/omniai#289). Merge + publish that first; CI here goes green once 3.7.0 is on RubyGems.
